### PR TITLE
[COOK-3324] Use BEncode.load_file to load torrent file when hashing to avoid UTF-8 encoding issues

### DIFF
--- a/providers/torrent_file.rb
+++ b/providers/torrent_file.rb
@@ -116,6 +116,6 @@ end
 def torrent_hash
   require 'bencode'
   @torrent_hash ||= begin
-    Digest::SHA1.hexdigest((IO.read(cached_torrent).bdecode["info"]).bencode) # thx bakins!
+    Digest::SHA1.hexdigest((BEncode.load_file(cached_torrent)["info"]).bencode) # thx bakins!
   end
 end


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3324

I'm not sure if I'm doing something wrong or my development system is a peculiar state, but the torrent files for a number of popular torrents were causing UTF-8 encoding issues for me when using the torrent_file provider from this cookbook.

The encoding errors were being thrown by BEncode when trying to parse the torrent file IO stream passed in from this cookbook. 

Looking at the issues for bencode, there had been an issue 2 years ago similar to this one with UTF-8 encoding issues in Ruby 1.9. The resolution to that issue was to change bencode to read torrent files in binary format. This change occurred in the method load_file in commit https://github.com/dasch/ruby-bencode/commit/5ebcf948b8de7fdc32bfd5c0d563f81a29f4c656

Since this cookbook doesn't use the load_file method and instead uses IO.read (which may use different internal/external encodings depending on the system), I suspect this cookbook opens itself to the same vulnerability. 

I've updated the cookbook to use bencode's built-in logic to handle opening torrent files  and haven't had any further issues.

I'm using ruby-1.9.3-p327 on Ubuntu 12.04 Desktop AMD64.

A couple of the torrents I had encoding issues with:
http://downloads.raspberrypi.org/images/raspbian/2012-12-16-wheezy-raspbian/2012-12-16-wheezy-raspbian.zip.torrent
http://releases.ubuntu.com/12.04/ubuntu-12.04.1-server-amd64.iso.torrent
