### PR TITLE
[COOK-3449] Prevent torrent status of checking from prematurely ending blocking downloads

### DIFF
--- a/providers/torrent_file.rb
+++ b/providers/torrent_file.rb
@@ -48,7 +48,7 @@ action :create do
           @torrent = @transmission.get_torrent(@torrent.hash_string)
           Chef::Log.debug("Downloading #{@new_resource}...#{@torrent.percent_done * 100}% complete")
           sleep 3
-        end while @torrent.downloading?
+        end while @torrent.downloading? || @torrent.checking?
         move_and_clean_up
         new_resource.updated_by_last_action(true)
       end


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3449

I ran into issues in this cookbook where the torrent_file provider, when performing a blocking download, would catch a new torrent in the checking state and interpret that to mean the torrent had completed when it really hadn't even begun.

I've updated the torrent_file provider to continue blocking while the torrent is downloading or checking. After this change, I haven't had any further premature exits and blocking downloads are working as advertised.
