### PR TITLE
[COOK-3450] Actually delete torrent local data when not seeding

### DIFF
--- a/libraries/torrent.rb
+++ b/libraries/torrent.rb
@@ -77,8 +77,7 @@ module Opscode
       end
 
       def remove_torrent(torrent_hash, delete_data=false)
-        #@transmission.send_request('torrent-remove', {'ids' => [torrent_hash], 'delete-local-data' => delete_data})
-        @transmission.send_request('torrent-remove', {'ids' => [torrent_hash]})
+        @transmission.send_request('torrent-remove', {'ids' => [torrent_hash], 'delete-local-data' => delete_data})
       end
     end
   end


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3450

I'm not sure if intentional or not, but the code to delete a torrent including the torrent's local data has been commented out since the initial commit. I suspect it may be unintentionally commented because other parts of the code seem clear in the intention to delete. 

I've uncommented the code and it seems to work as expected with the local data for the torrent being deleted with the torrent. I also tried the updated code with a torrent that was set to continue seeding the torrent and that also continued to work as expected.
