### PR TITLE
[COOK-3451] Use Hash#key to silence Hash#index deprecation warnings

### DIFF
--- a/libraries/torrent.rb
+++ b/libraries/torrent.rb
@@ -37,19 +37,19 @@ module TransmissionSimple
     }
     
     def downloading?
-      self.status == STATUS_CODES.index('DOWNLOAD')
+      self.status == STATUS_CODES.key('DOWNLOAD')
     end
 
     def stopped?
-      self.status == STATUS_CODES.index('STOPPED')
+      self.status == STATUS_CODES.key('STOPPED')
     end
 
     def checking?
-      self.status == STATUS_CODES.index('CHECK') || self.status == STATUS_CODES.index('CHECK_WAIT')
+      self.status == STATUS_CODES.key('CHECK') || self.status == STATUS_CODES.key('CHECK_WAIT')
     end
 
     def seeding?
-      self.status == STATUS_CODES.index('SEED')
+      self.status == STATUS_CODES.key('SEED')
     end
     
     def status_message


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3451

Update torrent library to use Hash#key instead of Hash#index to avoid warnings of Hash#index being deprecated.
