### PR TITLE
prevent circular symlink for settings.json

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -74,4 +74,5 @@ end
 
 link "/etc/transmission-daemon/settings.json" do
   to "#{node['transmission']['config_dir']}/settings.json"
+  not_if { File.symlink?("#{node['transmission']['config_dir']}/settings.json") }
 end


### PR DESCRIPTION
The transmisison-daemon package for ubuntu 14.04 creates /var/lib/transmission-daemon/info/settings.json as a symlink to /etc/transmission-daemon/settings.json .
The guard prevents the default recipe from linking /etc/transmission-daemon/settings.json back to /var/lib/transmission-daemon/info/settings.json.
