### PR TITLE
chore: migrate transmission to Policyfile

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+name 'transmission'
+
+run_list 'test::default'
+
+named_run_list :default, 'test::default'
+
+cookbook 'transmission', path: '.'
+cookbook 'test', path: './test/cookbooks/test'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT


### PR DESCRIPTION
## Summary

- Replace Berksfile with Policyfile.rb.
- Keep the default Kitchen suite as a named run list.
- Update ChefSpec and Copilot dependency installation.
- Keep Policyfile.lock.json ignored and untracked.

## Verification

- `chef install Policyfile.rb`
- `cookstyle`
- Chef Workstation RSpec: 22 examples
- `actionlint`
- `yamllint .`
- `markdownlint-cli2 '**/*.md'`
- `KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen test default-ubuntu-2204`